### PR TITLE
💥 Supports deletion of the third argument of Regexp.compile in Ruby 3.3.0

### DIFF
--- a/lib/log_line_parser/bots.rb
+++ b/lib/log_line_parser/bots.rb
@@ -41,12 +41,12 @@ Applebot
       end
       return if bot_names.empty?
       escaped_bots_str = bot_names.map {|name| Regexp.escape(name) }.join("|")
-      Regexp.compile(escaped_bots_str, Regexp::IGNORECASE, "n")
+      Regexp.compile(escaped_bots_str, Regexp::IGNORECASE)
     end
 
     def self.compile_re(bots_config)
       bots_pats = bots_config[ConfigLabels::BOTS_RE]
-      Regexp.compile(bots_pats.join("|"), nil, "n") if bots_pats
+      Regexp.compile(bots_pats.join("|"), nil) if bots_pats
     end
 
     private_class_method :compile_escaped_re, :compile_re


### PR DESCRIPTION
Supports deletion of the third argument of Regexp.compile in Ruby 3.3.0

* [Bug #20084 Breaking change with Regexp.new on 3.3.0](https://bugs.ruby-lang.org/issues/20084)
* [Bug #18797 Third argument to Regexp.new is a bit broken](https://bugs.ruby-lang.org/issues/18797)